### PR TITLE
Get pointcloud with normals

### DIFF
--- a/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/mesh_to_sampled_point_cloud.h
+++ b/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/mesh_to_sampled_point_cloud.h
@@ -44,9 +44,10 @@ public:
   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> getPointCloudXYZ();
 
   /**
-* Get the sampled point cloud as pcl point cloud with PointNormal as point type.
-* @return sampled point cloud
-*/
+   * Get the sampled point cloud as pcl point cloud with PointNormal as point type.
+   * @throws runtime_error if parameter write_normals_ == false
+   * @return sampled point cloud
+  */
   std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getPointCloudXYZN();
 
   /**

--- a/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/mesh_to_sampled_point_cloud.h
+++ b/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/mesh_to_sampled_point_cloud.h
@@ -44,6 +44,12 @@ public:
   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> getPointCloudXYZ();
 
   /**
+* Get the sampled point cloud as pcl point cloud with PointNormal as point type.
+* @return sampled point cloud
+*/
+  std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getPointCloudXYZN();
+
+  /**
    * Save the point cloud to a pcd file.
    * @param output_file
    */

--- a/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
+++ b/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
@@ -117,6 +117,7 @@ public:
 
   /**
    * Get the sampled point cloud as pcl point cloud with PointNormal as point type.
+   * @throws runtime_error if parameter write_normals == false
    * @return sampled point cloud
    */
   std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getSampledPointCloudXYZN();

--- a/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
+++ b/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
@@ -115,6 +115,10 @@ public:
    */
   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> getSampledPointCloudXYZ();
 
+  /**
+   * Get the sampled point cloud as pcl point cloud with PointNormal as point type.
+   * @return sampled point cloud
+   */
   std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getSampledPointCloudXYZN();
 
 

--- a/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
+++ b/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
@@ -117,7 +117,7 @@ public:
 
   /**
    * Get the sampled point cloud as pcl point cloud with PointNormal as point type.
-   * @throws runtime_error if parameter write_normals == false
+   * @throws runtime_error if parameter write_normals_ == false
    * @return sampled point cloud
    */
   std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getSampledPointCloudXYZN();

--- a/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
+++ b/mesh_to_sampled_point_cloud/include/mesh_to_sampled_point_cloud/pcl_mesh_sampling_extract.h
@@ -115,6 +115,8 @@ public:
    */
   std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> getSampledPointCloudXYZ();
 
+  std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getSampledPointCloudXYZN();
+
 
 private:
 

--- a/mesh_to_sampled_point_cloud/src/mesh_to_sampled_point_cloud.cpp
+++ b/mesh_to_sampled_point_cloud/src/mesh_to_sampled_point_cloud.cpp
@@ -38,6 +38,11 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> MeshToSampledPointCloud::getPoin
   return mesh_sampling_extract_.getSampledPointCloudXYZ();
 }
 
+std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> MeshToSampledPointCloud::getPointCloudXYZN()
+{
+  return mesh_sampling_extract_.getSampledPointCloudXYZN();
+}
+
 void MeshToSampledPointCloud::savePointCloudToPCDFile(const std::string& output_file)
 {
   // save file

--- a/mesh_to_sampled_point_cloud/src/pcl_mesh_sampling_extract.cpp
+++ b/mesh_to_sampled_point_cloud/src/pcl_mesh_sampling_extract.cpp
@@ -160,6 +160,20 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> PCLMeshSamplingExtract::getSampl
 }
 
 
+std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> PCLMeshSamplingExtract::getSampledPointCloudXYZN()
+{
+  if (!write_normals_)
+  {
+    std::cout << "Parameter \"write_normals\" must be set for calling this function" << std::endl;
+  }
+
+  std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> cloud_xyzn = std::make_shared<pcl::PointCloud<pcl::PointNormal>>();
+  // Strip colors from cloud:
+  pcl::copyPointCloud(*filtered_point_cloud_, *cloud_xyzn);
+  return cloud_xyzn;
+}
+
+
 
 // ===== pcl_mesh_sampling methods ===== //
 

--- a/mesh_to_sampled_point_cloud/src/pcl_mesh_sampling_extract.cpp
+++ b/mesh_to_sampled_point_cloud/src/pcl_mesh_sampling_extract.cpp
@@ -164,7 +164,8 @@ std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> PCLMeshSamplingExtract::getSa
 {
   if (!write_normals_)
   {
-    std::cout << "Parameter \"write_normals\" must be set for calling this function" << std::endl;
+    throw std::runtime_error("In PCLMeshSamplingExtract::getSampledPointCloudXYZN(): Point normals are invalid if flag "
+                             "\"write_normals\" not set.");
   }
 
   std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> cloud_xyzn = std::make_shared<pcl::PointCloud<pcl::PointNormal>>();


### PR DESCRIPTION
Can this be merged into main? It adds a function "getPoinCloudXYZN()" which works just like "getPointCloudXYZ()" but returns a <pcl::PointNormal> point cloud. We need this for our IP (repo robot_mesh_localization)